### PR TITLE
TypeError: "siblingRef is undefined"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-fomantic-ui",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-fomantic-ui",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ngx-fomantic-ui/src/modules/select/components/select.ts
+++ b/projects/ngx-fomantic-ui/src/modules/select/components/select.ts
@@ -71,7 +71,7 @@ export class FuiSelect<T, U> extends FuiSelectBase<T, U> implements ICustomValue
   public selectedOptionChange: EventEmitter<U>;
   // Stores the value written by ngModel before it can be matched to an option from `options`.
   private _writtenOption?: U;
-  @ViewChild('optionTemplateSibling', {read: ViewContainerRef, static: false})
+  @ViewChild('optionTemplateSibling', {read: ViewContainerRef, static: true})
   private _optionTemplateSibling: ViewContainerRef;
 
   constructor(element: ElementRef, localizationService: FuiLocalizationService) {


### PR DESCRIPTION
This PR fixes an issue with ngx-fomantic-ui and Angular 8.2. Templates that are used to create new DOM elements need to be references as static: true in @ViewChild annotation // tested and worked.